### PR TITLE
Update README_suitecrm.md

### DIFF
--- a/README_suitecrm.md
+++ b/README_suitecrm.md
@@ -23,7 +23,7 @@ Log calls for "Calls" module.
     | TextField | asterlink_uid          | Asterisk UID  | 64       |
     | Phone     | asterlink_cid          | CallerID      | 32       |
 * Add new fields for Users module:
-  * Administrator -> Studio -> Calls -> Fields
+  * Administrator -> Studio -> Users -> Fields
   * New fields:
     | Data Type | Field Name             | Display Label       | Max Size |
     |-----------|------------------------|---------------------|----------|


### PR DESCRIPTION
This appears to be a copy paste typo and I expect the new field needs to be added to the Users section.
This makes sense to allow the asterlink_ext to be added to the user for editing through the CRM, and would otherwise simply be bundled in the 'New Fields' above